### PR TITLE
nullishな返却値が戻ったときにエラーが発生する

### DIFF
--- a/lib/commands/eval.js
+++ b/lib/commands/eval.js
@@ -18,7 +18,7 @@ class Eval extends CommandBase {
     exec(...args) {
         const code = args.join(' ');
         try {
-            return vm.runInNewContext(code, {}, { timeout: 5000 })?.toString();
+            return String(vm.runInNewContext(code, {}, { timeout: 5000 }));
         } catch (error) {
             return 'Oops! Some **ERROR** occured during evaluating script!';
         }

--- a/lib/commands/eval.js
+++ b/lib/commands/eval.js
@@ -18,7 +18,7 @@ class Eval extends CommandBase {
     exec(...args) {
         const code = args.join(' ');
         try {
-            return vm.runInNewContext(code, {}, { timeout: 5000 }).toString();
+            return vm.runInNewContext(code, {}, { timeout: 5000 })?.toString();
         } catch (error) {
             return 'Oops! Some **ERROR** occured during evaluating script!';
         }


### PR DESCRIPTION
### やったこと
- eval コマンドの変更
    - ~toString()の呼び出しをOptional Chainingに変更~
    - toString()ではなくString()による型変換に変更
### レビュー観点
- [x] ~Botの動作している環境でOptional Chainingは使用可能か~
- [x] 変更点にタイポ等の問題はないか
### 今回の変更による影響
- `!bot eval console.log("hoge")`
- `!bot eval`
- `!bot eval void 0`
- `!bot eval null`
などでエラーにならずundefinedやnullが返却されるようになる