### PR TITLE
refactor:#17 検索系APIのバックエンドをDuckDuckGoに置き換え

### DIFF
--- a/lib/bot-utils.ts
+++ b/lib/bot-utils.ts
@@ -64,6 +64,20 @@ export function randomInt(n: number) {
 }
 
 /**
+ * 長さが0の場合にtrueを返す
+ */
+export function isEmpty(seq: { length: number }) {
+    return seq.length === 0;
+}
+
+/**
+ * 配列から1要素をランダムに取り出す
+ */
+export function pickUpRandom<T>(items: T[]) {
+    return items[randomInt(items.length)];
+}
+
+/**
  * 関数のメモ化関数
  */
 export function IdiotCache<T extends Function>(f: T) {

--- a/lib/commands/search-image.ts
+++ b/lib/commands/search-image.ts
@@ -1,7 +1,5 @@
-import fetch from 'node-fetch';
-
 import { CommandBase } from '../command-base';
-import { objectToQueryString, randomInt } from '../bot-utils';
+import { parseSearchArgs, searchImage } from '../search-utils';
 
 
 /**
@@ -12,38 +10,11 @@ export default class SearchImage extends CommandBase {
         super();
         this.name = 'searchImage';
         this.description =
-            '`searchImage [...keywords]`: search image using given keywords';
+            '`searchImage [--strict | --unsafe] [...keywords]`: search image using given keywords';
     }
 
     async exec(...args: string[]) {
-        const keyword = args.join(' ');
-        return await this.searchImage(keyword);
-    }
-
-    /**
-     * 画像を検索してくる
-     */
-    async searchImage(keyword: string) {
-        const url = 
-            'https://search.yahoo.co.jp/image/search' +
-            objectToQueryString({
-                p: encodeURIComponent(keyword),
-                ei: 'UTF-8'
-            });
-        const res = await fetch(url);
-        const html = await res.text();
-        const imageLinks = html.match(/(?<=\"original\":{\"url\":\").+?(?=\")/sg) || [];
-        while (imageLinks.length) {
-            const imageLink = imageLinks.splice(randomInt(imageLinks.length))[0];
-            const res = await fetch(imageLink);
-            const contentType =
-                res.headers.get('content-type') ||
-                res.headers.get('Content-Type') ||
-                '';
-            if (res.status < 300 && contentType.includes('image')) {
-                return imageLink;
-            }
-        }
-        return 'Oops! Image not found.';
+        const { keyword, safeLevel } = parseSearchArgs(args);
+        return await searchImage(keyword, safeLevel);
     }
 }

--- a/lib/commands/search-video.ts
+++ b/lib/commands/search-video.ts
@@ -1,7 +1,5 @@
-import fetch from 'node-fetch';
-
 import { CommandBase } from '../command-base';
-import { objectToQueryString, randomInt } from '../bot-utils';
+import { parseSearchArgs, searchVideo } from '../search-utils';
 
 
 /**
@@ -12,32 +10,11 @@ export default class SearchVideo extends CommandBase {
         super();
         this.name = 'searchVideo';
         this.description =
-            '`searchVideo [...keywords]`: search video using given keywords';
+            '`searchVideo [--strict | --unsafe] [...keywords]`: search video using given keywords';
     }
 
     async exec(...args: string[]) {
-        const keyword = args.join(' ');
-        return await this.searchImage(keyword);
-    }
-
-    /**
-     * 動画を検索してくる
-     */
-    async searchImage(keyword: string) {
-        const url = 
-            'https://search.yahoo.co.jp/video/search' +
-            objectToQueryString({
-                p: encodeURIComponent(keyword),
-                ei: 'UTF-8'
-            });
-        const res = await fetch(url);
-        const html = await res.text();
-        const videoLinks = html.match(/(?<=\"refererUrl\":\").+?(?=\")/sg) || [];
-        const uniqueLinks = [...new Set(videoLinks)];
-        if (uniqueLinks.length) {
-            return uniqueLinks[randomInt(uniqueLinks.length)];
-        } else {
-            return 'Oops! Video not found.';
-        }
+        const { keyword, safeLevel } = parseSearchArgs(args);
+        return await searchVideo(keyword, safeLevel);
     }
 }

--- a/lib/search-utils.ts
+++ b/lib/search-utils.ts
@@ -1,0 +1,178 @@
+import fetch from 'node-fetch';
+
+import { objectToQueryString, isEmpty, pickUpRandom } from './bot-utils';
+
+
+type SafeLevel = 'strict' | 'normal' | 'unsafe';
+type SearchTarget = 'images' | 'videos';
+
+type SearchResponseBase = {
+  ads: null;
+  next: string;
+  query: string;
+  queryEncoded: string;
+  response_type: SearchTarget;
+};
+
+type SearchImageResponseResultItem = {
+  height: number;
+  image: string;
+  source: string;
+  thumbnail: string;
+  thumbnail_token: string;
+  title: string;
+  url: string;
+  width: number;
+};
+
+type SearchVideoResponseResultItem = {
+  content: string;
+  description: string;
+  duration: string;
+  embed_html: string;
+  embed_url: string;
+  image_token: string;
+  images: {
+    large: string;
+    medium: string;
+    motion: string;
+    small: string;
+  };
+  provider: string;
+  published: string;
+  statistics: {
+    viewCount: number;
+  };
+  title: string;
+  uploader: string;
+};
+
+type SearchImageResponse = SearchResponseBase & {
+  results: SearchImageResponseResultItem[];
+};
+
+type SearchVideoResponse = SearchResponseBase & {
+  results: SearchVideoResponseResultItem[];
+}
+
+
+/**
+ * 文字列の引数列から検索用オプションを生成する
+ */
+export function parseSearchArgs(args: string[]) {
+  if (['--strict', '--unsafe'].includes(args[0])) {
+    return {
+      keyword: args.slice(1).join(' '),
+      safeLevel: args[0].replace('--', '') as SafeLevel,
+    } as const;
+  } else {
+    return {
+      keyword: args.join(' '),
+      safeLevel: 'normal' as SafeLevel,
+    } as const;
+  }
+}
+
+/**
+ * DuckDuckGoを用いた画像検索
+ */
+export async function searchImage(keyword: string, safeLevel: SafeLevel) {
+  const cookie = generateDdgCookie(safeLevel);
+  const searchPageContent = await fetchDdgSearchPage('images', keyword, cookie)
+  const vqd = getVqd(searchPageContent);
+  if (isEmpty(vqd)) {
+    return 'Oops! Something went wrong. Searching image failed.'
+  }
+  const searchApiContent = await fetchDdgSearchApi('images', keyword, vqd, safeLevel, cookie);
+  if (isEmpty(searchApiContent.results)) {
+    return 'Oops! Image not found.';
+  }
+  const result = pickUpRandom(searchApiContent.results);
+  return generateImageUrl(result, safeLevel);
+}
+
+/**
+ * DuckDuckGoを用いた動画検索
+ */
+export async function searchVideo(keyword: string, safeLevel: SafeLevel) {
+  const cookie = generateDdgCookie(safeLevel);
+  const searchPageContent = await fetchDdgSearchPage('videos', keyword, cookie)
+  const vqd = getVqd(searchPageContent);
+  if (isEmpty(vqd)) {
+    return 'Oops! Something went wrong. Searching video failed.'
+  }
+  const searchApiContent = await fetchDdgSearchApi('videos', keyword, vqd, safeLevel, cookie);
+  if (isEmpty(searchApiContent.results)) {
+    return 'Oops! Video not found.';
+  }
+  const result = pickUpRandom(searchApiContent.results);
+  return result.content;
+}
+
+
+function generateDdgCookie(safeLevel: SafeLevel) {
+  const safeLevelToken =
+    safeLevel === 'strict' ? '1'
+    : safeLevel === 'normal' ? '-1'
+    : '-2';
+  return `ah=jp-jp; l=jp-jp; 5=1; ay=b; p=${safeLevelToken}; ae=t;`;
+}
+
+async function fetchDdgSearchPage(
+  searchTarget: SearchTarget,
+  keyword: string,
+  cookie: string
+) {
+  const frontPageUrl =
+    'https://duckduckgo.com/' +
+    objectToQueryString({
+      q: encodeURIComponent(keyword),
+      ia: searchTarget,
+      iax: searchTarget,
+    });
+  const frontPageRes = await fetch(frontPageUrl, { headers: { cookie } });
+  return decodeURIComponent(await frontPageRes.text());
+}
+
+function getVqd(content: string) {
+  return content.match(/(?<=vqd=)\d.+?(?=&)/)?.[0] ?? '';
+}
+
+async function fetchDdgSearchApi<T extends SearchTarget>(
+  searchTarget: T,
+  keyword: string,
+  vqd: string,
+  safeLevel: SafeLevel,
+  cookie: string
+) {
+  const targetScript =
+    searchTarget === 'images' ? 'i.js' : 'v.js';
+  const searchApiUrl =
+    `https://duckduckgo.com/${targetScript}` +
+    objectToQueryString({
+      l: 'jp-jp',
+      o: 'json',
+      q: encodeURIComponent(keyword),
+      vqd,
+      p: safeLevel === 'strict' ? '1' : '-1',
+    });
+  const searchApiRes = await fetch(searchApiUrl, { headers: { cookie } });
+  return await searchApiRes.json() as (
+    T extends 'images' ? SearchImageResponse : SearchVideoResponse
+  );
+}
+
+function generateImageUrl(searchResult: SearchImageResponseResultItem, safeLevel: SafeLevel) {
+  const imageUrl =
+    'https://external-content.duckduckgo.com/iu/' +
+    objectToQueryString({
+      u: searchResult.thumbnail,
+      f: '1',
+      ipt: searchResult.thumbnail_token,
+      ipo: 'images',
+    });
+  if (safeLevel === 'unsafe') {
+    return `<${imageUrl}>`;
+  }
+  return imageUrl;
+}

--- a/tests/commands/test-search-image.ts
+++ b/tests/commands/test-search-image.ts
@@ -16,4 +16,6 @@ const instance = new SearchImage();
 
     console.log(await instance.exec('tsurutaaaaaa_', '結婚'));
 
+    console.log(await instance.exec('--unsafe', 'かのゆら'));
+
 })();

--- a/tests/commands/test-search-video.ts
+++ b/tests/commands/test-search-video.ts
@@ -8,4 +8,6 @@ const instance = new SearchVideo();
 
     console.log(await instance.exec('ぴえん'));
 
+    console.log(await instance.exec('--unsafe', 'tri poloski'));
+
 })();


### PR DESCRIPTION
## 変更点

- [ ] 画像と動画の検索機能のバックエンドをDuckDuckGoに置き換え
- [ ] それぞれにセーフサーチオプション（デフォルトで標準）を追加